### PR TITLE
att versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.8.0"
+agp = "8.8.1"
 dotlottieAndroid = "0.6.2"
 kotlin = "2.0.0"
 coreKtx = "1.15.0"
@@ -9,8 +9,8 @@ espressoCore = "3.6.1"
 kotlinxSerializationJson = "1.8.0"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.0"
-composeBom = "2025.01.01"
-navigationCompose = "2.8.6"
+composeBom = "2025.02.00"
+navigationCompose = "2.8.7"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
att versions libs

- agp "8.8.0" for "8.8.1"
- composeBom "2025.01.01" for "2025.02.00"
- navigationCompose "2.8.6" for "2.8.7"